### PR TITLE
showing calendar week start and end for planning blocks in tooltips

### DIFF
--- a/workbench/planning/reporting.py
+++ b/workbench/planning/reporting.py
@@ -113,6 +113,11 @@ class Planning:
                             (
                                 str(pw.service_type) if pw.service_type else None,
                                 _("%.1fh per week") % per_week,
+                                _("KW %s-%s")
+                                % (
+                                    local_date_format(date_from, fmt="W"),
+                                    local_date_format(date_until, fmt="W"),
+                                ),
                             ),
                         )
                     ),


### PR DESCRIPTION
Shy display of calender weeks in tooltip for planning blocks. Gaps ignored. 