### PR TITLE
Add project jump fixed button

### DIFF
--- a/workbench/static/workbench/main.scss
+++ b/workbench/static/workbench/main.scss
@@ -306,6 +306,20 @@ tbody th > a {
   background-image: url("lib/break.svg");
 }
 
+.fixed-btn.project {
+  left: 7.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-image: none;
+}
+
+.fixed-btn.project svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  fill: currentColor;
+}
+
 .widget--checkboxselectmultiple .my-2 {
   /* column-width: 15rem; */
 }

--- a/workbench/templates/base.html
+++ b/workbench/templates/base.html
@@ -288,6 +288,14 @@
   <!-- /container -->
   {% block fixed-add-button %}
     <a
+      href="{% url 'projects_project_select' %}"
+      data-ajaxmodal
+      class="btn btn-primary fixed-btn project"
+      title="{% translate 'Jump to project' %}"
+    >
+      {% include "svg/project.svg" %}
+    </a>
+    <a
       href="{% url 'logbook_loggedhours_create' %}"
       data-createhours
       data-ajaxmodal

--- a/workbench/templates/projects/project_detail.html
+++ b/workbench/templates/projects/project_detail.html
@@ -727,6 +727,12 @@
 {% endblock content %}
 
 {% block fixed-add-button %}
+  <a href="{% url 'projects_project_select' %}"
+     data-ajaxmodal
+     class="btn btn-primary fixed-btn project"
+     title="{% translate 'Jump to project' %}">
+    {% include "svg/project.svg" %}
+  </a>
   <a href="{{ project.urls.createhours }}"
      data-createhours
      data-ajaxmodal


### PR DESCRIPTION
## Summary

- Add a fixed “Jump to project” button alongside the existing floating log-hours and break actions.
- Open the existing project selection modal through the `projects_project_select` route.
- Add styling for the new project fixed button using the existing project icon.

## Testing

- `./runtests.sh workbench.projects.test_projects`

